### PR TITLE
Secure buddies#106

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -25,15 +25,22 @@ export default class extends React.Component {
     }
   }
 
-  componentDidMount() {
-    auth.onAuthStateChanged(user => {
+  componentWillMount() {
+    // Stef says: It occurs to me that here we may not want a listener
+    // but a once off check... Am funelling down the unsub to the
+    // TitleBar to try to redirect properly on logout.
+    this.unsubscribeAuth = auth.onAuthStateChanged(user => {
+      console.log('APP COMPONENT_WILL_MOUNT, USER: ', user)
       user ?
       this.setState({
         userId: user.uid
       }) : browserHistory.push('/login?' + this.props.params.tripId)
     })
+    this.unsubscribeAuth = this.unsubscribeAuth.bind(this)
   }
-
+  componentWillUnmount() {
+    this.unsubscribeAuth && this.unsubscribeAuth()
+  }
   render() {
     // console.log('STATE in APP:', this.state)
     // console.log('TRIP REF in APP:', db.ref('/trips/'+ this.props.params.tripId))
@@ -41,6 +48,7 @@ export default class extends React.Component {
       <div>
         <TitleBar
           auth={auth}
+          unsubscribeAuth={this.unsubscribeAuth}
           tripsRef={db.ref('trips')}
           tripId={this.state.tripId}
           userId={this.state.userId ? this.state.userId : 'test'}
@@ -57,5 +65,3 @@ export default class extends React.Component {
     )
   }
 }
-
-

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -21,34 +21,24 @@ export default class extends React.Component {
     this.state = {
       userId: '',
       tripId: props.params.tripId,
-      // buddies: []
     }
   }
 
   componentWillMount() {
-    // Stef says: It occurs to me that here we may not want a listener
-    // but a once off check... Am funelling down the unsub to the
-    // TitleBar to try to redirect properly on logout.
-    this.unsubscribeAuth = auth.onAuthStateChanged(user => {
-      console.log('APP COMPONENT_WILL_MOUNT, USER: ', user)
-      user ?
-      this.setState({
-        userId: user.uid
-      }) : browserHistory.push('/login?' + this.props.params.tripId)
-    })
-    this.unsubscribeAuth = this.unsubscribeAuth.bind(this)
-  }
-  componentWillUnmount() {
-    this.unsubscribeAuth && this.unsubscribeAuth()
+    // console.log('APP COMPONENT_WILL_MOUNT, auth.currentUSer: ', auth.currentUser)
+    auth.currentUser ?
+    this.setState({
+      userId: auth.currentUser.uid
+    }) : browserHistory.push('/login?' + this.props.params.tripId)
   }
   render() {
     // console.log('STATE in APP:', this.state)
     // console.log('TRIP REF in APP:', db.ref('/trips/'+ this.props.params.tripId))
-    return (
+    return this.state.userId ?
+      (
       <div>
         <TitleBar
           auth={auth}
-          unsubscribeAuth={this.unsubscribeAuth}
           tripsRef={db.ref('trips')}
           tripId={this.state.tripId}
           userId={this.state.userId ? this.state.userId : 'test'}
@@ -63,5 +53,7 @@ export default class extends React.Component {
           />
       </div>
     )
+    :
+    null
   }
 }

--- a/app/components/InlineBuddyEdit.jsx
+++ b/app/components/InlineBuddyEdit.jsx
@@ -41,7 +41,7 @@ export default class InlineBuddyEdit extends Component {
     // When the component mounts, start listening to the usersRef
     // we were given.
     this.props.auth.onAuthStateChanged(user => {
-      this.setState({
+      user && this.setState({
         email: user.email
       })
     })

--- a/app/components/Login.jsx
+++ b/app/components/Login.jsx
@@ -29,7 +29,7 @@ export default class extends React.Component {
     }
   }
   componentDidMount() {
-    this.unsubscribe = auth && auth.onAuthStateChanged(user => this.setState({ user }))
+    this.unsubscribe = auth && auth.onAuthStateChanged(user => user && this.setState({ user }))
   }
 
   componentWillUnmount() {

--- a/app/components/SignUp.jsx
+++ b/app/components/SignUp.jsx
@@ -24,7 +24,6 @@ export default class extends React.Component {
     queryString ? this.addToTrip(userCredential.user, queryString) : this.createNewTrip(userCredential.user)
   }
 
-
   onSubmit = (evt) => {
     evt.preventDefault()
     // console.log('MADE IT TO ON SUBMIT')

--- a/app/components/TitleBar.jsx
+++ b/app/components/TitleBar.jsx
@@ -119,8 +119,8 @@ export default class TitleBar extends React.Component {
                   padding: '3px 6px'
                 }}
                 onClick={() => {
+                  this.props.unsubscribeAuth()
                   auth.signOut()
-                  browserHistory.push('/login')
                 }}>logout
                 </button>
               :

--- a/app/components/TitleBar.jsx
+++ b/app/components/TitleBar.jsx
@@ -16,17 +16,22 @@ export default class TitleBar extends React.Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     // console.log('TITLE BAR ComponentWILLMOUNT,  PROPS', this.props)
     this.unsubscribe = this.props.tripRef
-      .on('value', snapshot => {
-        const tripObj = snapshot.val()
-        idToNameOrEmail(this.props.userId)
-        .then(nameOrEmail => this.setState({
-          tripName: tripObj.tripName,
-          userName: nameOrEmail
-        })).catch(console.error)
-      })
+    .on('value', snapshot => {
+      // console.log('TITLE BAR DID_MOUNT: tripRef, snapshot', this.props.tripRef, snapshot)
+      // Stef says: Weird edge case on logout:  tripRef and snapshot log as existing
+      // but snapshot.val() finds snapshot undefined...
+      // safety (hack?) is the if below:
+      if (!snapshot) return function() {}
+      const tripObj = snapshot.val()
+      idToNameOrEmail(this.props.userId)
+      .then(nameOrEmail => this.setState({
+        tripName: tripObj.tripName,
+        userName: nameOrEmail
+      })).catch(console.error)
+    })
   }
   componentWillUnmount() {
     // console.log('TITLE BAR ComponentWILL_UNMOUNT')
@@ -119,8 +124,8 @@ export default class TitleBar extends React.Component {
                   padding: '3px 6px'
                 }}
                 onClick={() => {
-                  this.props.unsubscribeAuth()
                   auth.signOut()
+                  browserHistory.push('/login')
                 }}>logout
                 </button>
               :

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -22,12 +22,16 @@ const google = new firebase.auth.GoogleAuthProvider()
 const email = new firebase.auth.EmailAuthProvider()
 // Deleted facebook --> can reimplement if we have time, hahahahhaahahaahhah
 
-const Container = () =>
+const Container = () => {
+  // console.log('CONTAINER in MAIN, currentUser', firebase.auth().currentUser)
+  return (
   <div className="container-fluid">
     {
       firebase.auth().currentUser ? <App /> : <Login />
     }
   </div>
+  )
+}
 
 render(
   <Router history={browserHistory}>

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -22,15 +22,34 @@ const google = new firebase.auth.GoogleAuthProvider()
 const email = new firebase.auth.EmailAuthProvider()
 // Deleted facebook --> can reimplement if we have time, hahahahhaahahaahhah
 
-const Container = () => {
-  // console.log('CONTAINER in MAIN, currentUser', firebase.auth().currentUser)
-  return (
-  <div className="container-fluid">
-    {
-      firebase.auth().currentUser ? <App /> : <Login />
+export default class Container extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      user: null
     }
-  </div>
-  )
+  }
+  componentWillMount() {
+    this.unsubscribe = auth.onAuthStateChanged(user => {
+      // console.log('CONTAINER COMPONENT_WILL_MOUNT, USER: ', user)
+      this.setState({
+        user: user
+      })
+    })
+  }
+  componentWillUnmount() {
+    this.unsubscribe && this.unsubscribe()
+  }
+  render() {
+    // console.log('CONTAINER in MAIN, currentUser', firebase.auth().currentUser)
+    return (
+      <div className="container-fluid">
+        {
+          this.state.user ? <App /> : <Login />
+        }
+      </div>
+    )
+  }
 }
 
 render(


### PR DESCRIPTION
Places auth listener in Container,  and a once off auth check in App to test for dashboard/tripId entry point redirect for users new to the trip. Logout is now deparameterized. and renders properly only Login,  and finally, URL matches to /login. 